### PR TITLE
Defaults and provider

### DIFF
--- a/cluster_profile.tfvars.example
+++ b/cluster_profile.tfvars.example
@@ -1,20 +1,4 @@
-# Specify GCP Credentials JSON below
-project_id = "massive-bliss-781"
-name_prefix = "mbernadin"
-dcos_cluster_name = "Prod Cluster"
-infra_disk_type = "pd-ssd" # Optional
-infra_disk_size = "128"
-infra_machine_type = "n1-standard-8"
-#infra_ssh_user = "core"
-infra_dcos_instance_os = "coreos_1576.5.0"
-infra_public_ssh_key_path = "~/.ssh/key.pub"
-region = "us-west1"
+name_prefix = "dcos-example"
+dcos_cluster_name = "dcos-example"
+infra_public_ssh_key_path = "~/.ssh/id_rsa.pub"
 dcos_version = "1.11.4"
-
-####
-####
-
-num_masters = "3"
-num_private_agents = "1"
-num_public_agents = "1"
-dcos_type = "open"

--- a/main.tf
+++ b/main.tf
@@ -12,11 +12,6 @@ module "dcos-infrastructure" {
   infra_dcos_instance_os    = "${var.infra_dcos_instance_os}"
   infra_public_ssh_key_path = "${var.infra_public_ssh_key_path}"
   dcos_version              = "${var.dcos_version}"
-  billing_account           = "${var.billing_account}"
-  project_id                = "${var.project_id}"
-  region                    = "${var.region}"
-  credentials               = "${var.credentials}"
-  dcos_version              = "${var.dcos_version}"
   num_masters               = "${var.num_masters}"
   num_private_agents        = "${var.num_private_agents}"
   num_public_agents         = "${var.num_public_agents}"
@@ -25,10 +20,8 @@ module "dcos-infrastructure" {
   infra_ssh_user            = "${var.infra_ssh_user}"
   tags                      = "${var.tags}"
 
-  # org_id = "998989278031"
-
   providers = {
-    aws = "google"
+    google = "google"
   }
 }
 

--- a/variable.tf
+++ b/variable.tf
@@ -3,7 +3,9 @@
 #########################
 
 #
-variable "name_prefix" {}
+variable "name_prefix" {
+  default = "dcos-gcp-example"
+}
 
 # GCP Builing Account
 variable "billing_account" {
@@ -15,9 +17,6 @@ variable "org_id" {
   default = ""
 }
 
-# Existing Project ID
-variable "project_id" {}
-
 # Master CIDR Range
 variable "master_cidr_range" {
   default = "10.64.0.0/16"
@@ -26,11 +25,6 @@ variable "master_cidr_range" {
 # Agent CIDR Range
 variable "agent_cidr_range" {
   default = "10.65.0.0/16"
-}
-
-# GCP Credentials JSON
-variable "credentials" {
-  default = ""
 }
 
 # Bootstrap node disk size (gb)
@@ -165,7 +159,6 @@ variable "infra_ssh_user" {
 
 # Global Infra Public SSH Key
 variable "infra_public_ssh_key_path" {
-  default = ""
 }
 
 # Global Infra Disk Type
@@ -215,12 +208,12 @@ variable "bootstrap_dcos_instance_os" {
 
 # Number of Masters
 variable "num_masters" {
-  default = "1"
+  default = "3"
 }
 
 # Number of Private Agents
 variable "num_private_agents" {
-  default = "1"
+  default = "2"
 }
 
 # Number of Public Agents


### PR DESCRIPTION
- use default provider and forward it to infrastructure
- added default to `name_prefix` only ssh key is mandatory
- updated default cluster size to 3 master 2 private and 1 public agent
- cleaned example vars file
