### PR TITLE
docs: updating default coreos version

### DIFF
--- a/docs/published/README.md
+++ b/docs/published/README.md
@@ -115,6 +115,7 @@ data "http" "whatismyip" {
 module "dcos" {
   source = "dcos-terraform/dcos/gcp"
 
+  dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"
   admin_ips           = ["${data.http.whatismyip.body}/32"]
@@ -217,6 +218,7 @@ data "http" "whatismyip" {
 module "dcos" {
   source = "dcos-terraform/dcos/gcp"
 
+  dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"
   admin_ips           = ["${data.http.whatismyip.body}/32"]
@@ -303,6 +305,7 @@ data "http" "whatismyip" {
 module "dcos" {
   source = "dcos-terraform/dcos/gcp"
 
+  dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"
   admin_ips           = ["${data.http.whatismyip.body}/32"]

--- a/docs/published/main.tf
+++ b/docs/published/main.tf
@@ -10,6 +10,7 @@ data "http" "whatismyip" {
 module "dcos" {
   source = "dcos-terraform/dcos/gcp"
 
+  dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos-cluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"
   admin_ips           = ["${data.http.whatismyip.body}/32"]


### PR DESCRIPTION
We need to update the CoreOS version in our default templates from CoreOS 1235 => CoreOS 1855.5 as it is now our most supported version.

See below:
https://docs.mesosphere.com/version-policy/

https://jira.mesosphere.com/browse/DCOS-44377