### PR TITLE
docs: adding version support to convenience wrapper

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -76,7 +76,8 @@ The default variables inputs are tracked in the [terraform-gcp-dcos](https://reg
 $ cat main.tf
 ...
 module "dcos" {
-  source = "dcos-terraform/dcos/gcp"
+  source  = "dcos-terraform/dcos/gcp"
+  version = "~> 0.1"
 
   # additional example variables in the module
   dcos_version = "1.11.5"

--- a/docs/published/README.md
+++ b/docs/published/README.md
@@ -113,7 +113,8 @@ data "http" "whatismyip" {
 }
 
 module "dcos" {
-  source = "dcos-terraform/dcos/gcp"
+  source  = "dcos-terraform/dcos/gcp"
+  version = "~> 0.1"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
@@ -216,7 +217,8 @@ data "http" "whatismyip" {
 }
 
 module "dcos" {
-  source = "dcos-terraform/dcos/gcp"
+  source  = "dcos-terraform/dcos/gcp"
+  version = "~> 0.1"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
@@ -303,7 +305,8 @@ data "http" "whatismyip" {
 }
 
 module "dcos" {
-  source = "dcos-terraform/dcos/gcp"
+  source  = "dcos-terraform/dcos/gcp"
+  version = "~> 0.1"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"

--- a/docs/published/main.tf
+++ b/docs/published/main.tf
@@ -8,7 +8,8 @@ data "http" "whatismyip" {
 }
 
 module "dcos" {
-  source = "dcos-terraform/dcos/gcp"
+  source  = "dcos-terraform/dcos/gcp"
+  version = "~> 0.1"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos-cluster"


### PR DESCRIPTION
If an operator wanted to control the submodules in the dcos-terraform provisioner, he may need a working example of how this looks like but also it needs to be pinned at the operator level. In the event the user wanted to latest version of dcos to upgrade to, when the user subsequently runs the `terraform get --update`, not only will the dcos layer be updated,  but also the infrastructure layer. 

This change will pin the infra layer, while keeping the control of the dcos-layer free for updates as the minor version will most likely not change in the near future.