### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ EXAMPLE
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -77,7 +77,7 @@ $ cat main.tf
 ...
 module "dcos" {
   source  = "dcos-terraform/dcos/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   # additional example variables in the module
   dcos_version = "1.11.5"

--- a/docs/published/README.md
+++ b/docs/published/README.md
@@ -114,7 +114,7 @@ data "http" "whatismyip" {
 
 module "dcos" {
   source  = "dcos-terraform/dcos/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
@@ -218,7 +218,7 @@ data "http" "whatismyip" {
 
 module "dcos" {
   source  = "dcos-terraform/dcos/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"
@@ -306,7 +306,7 @@ data "http" "whatismyip" {
 
 module "dcos" {
   source  = "dcos-terraform/dcos/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos"

--- a/docs/published/main.tf
+++ b/docs/published/main.tf
@@ -9,7 +9,7 @@ data "http" "whatismyip" {
 
 module "dcos" {
   source  = "dcos-terraform/dcos/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos-cluster"

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@
  *```hcl
  * module "dcos" {
  *   source  = "dcos-terraform/dcos/gcp"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   cluster_name = "mydcoscluster"
  *   ssh_public_key_file = "~/.ssh/id_rsa.pub"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2