### PR TITLE
main/readme: pinned this version to gcp 2.X.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ EXAMPLE
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   cluster_name = "mydcoscluster"
   ssh_public_key_file = "~/.ssh/id_rsa.pub"

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@
  *```hcl
  * module "dcos" {
  *   source  = "dcos-terraform/dcos/gcp"
- *   version = "~> 0.1.0"
+ *   version = "~> 0.2.0"
  *
  *   cluster_name = "mydcoscluster"
  *   ssh_public_key_file = "~/.ssh/id_rsa.pub"
@@ -71,7 +71,9 @@
  *```
  */
 
-provider "google" {}
+provider "google" {
+  version = "~> 2.0"
+}
 
 resource "random_id" "id" {
   byte_length = 2
@@ -84,7 +86,7 @@ locals {
 
 module "dcos-infrastructure" {
   source  = "dcos-terraform/infrastructure/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   cluster_name = "${local.cluster_name}"
 


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-48802

As GCP update the latest version of the provider, we now require to update the templates so that it can select the proper version associated with the change.