### PR TITLE
gcp: reverting fail on exit for fault-domain-detect

### DIFF
--- a/scripts/fault-domain-detect.sh
+++ b/scripts/fault-domain-detect.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -o nounset -o errexit
 
 AWS_URL="http://169.254.169.254/latest/dynamic/instance-identity/document"
 


### PR DESCRIPTION
Due to the nature of the Mesosphere provided fault domain script that was previously written for cloud providers, it doesn work well with the `set -o nounset -o errexit` dur to the how it checks each cloud provider's metadata endpoint. This change reverts this back.