### PR TITLE
Add support for plaintext public ssh key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,7 @@ module "dcos-infrastructure" {
 
   infra_dcos_instance_os    = "${var.dcos_instance_os}"
   infra_public_ssh_key_path = "${var.ssh_public_key_file}"
+  infra_public_ssh_key      = "${var.ssh_public_key}"
 
   bootstrap_image            = "${var.bootstrap_gcp_image}"
   bootstrap_machine_type     = "${var.bootstrap_machine_type}"


### PR DESCRIPTION
This PR depends on https://github.com/dcos-terraform/terraform-gcp-infrastructure/pull/11

It calls on the infrastructure module and passing the existing `ssh_public_key` variable. No breaking changes for this module. 

Addresses https://github.com/dcos-terraform/terraform-gcp-instance/issues/9