### PR TITLE
Change modules to use google-beta provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@
  *```
  */
 
-provider "google" {}
+provider "google-beta" {}
 
 resource "random_id" "id" {
   byte_length = 2
@@ -126,7 +126,7 @@ module "dcos-infrastructure" {
   dcos_version = "${var.dcos_version}"
 
   providers = {
-    google = "google"
+    google-beta = "google-beta"
   }
 }
 


### PR DESCRIPTION
In order to not require pinning to an older version of the terraform provider (dcos-terraform/terraform-gcp-dcos#24) the options appear to be 1) remove usage of beta features or 2) move to the google-beta provider. This PR is an attempt at option 2.